### PR TITLE
support custom delimiters and gzipped files

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,12 @@ See below for an exhaustive list of configuration fields:
             // format, either "csv" or "excel"
             "format": "csv",
 
+            // record delimter (optional), defaults to ","
+            "delimiter": "|",
+
+            // if true, unzip the file before reading it at a csv
+            "unzip": true,
+
             // if the files don't have a header row, you can specify the field names
             "field_names": ["id", "first_name", "last_name"],
 

--- a/README.md
+++ b/README.md
@@ -136,6 +136,10 @@ See below for an exhaustive list of configuration fields:
             // if true, unzip the file before reading it at a csv
             "unzip": true,
 
+            // if specified, override the default CSV quoting config
+            // More info: https://docs.python.org/3/library/csv.html#csv.QUOTE_ALL
+            "quoting": "QUOTE_NONE",
+
             // if the files don't have a header row, you can specify the field names
             "field_names": ["id", "first_name", "last_name"],
 

--- a/tap_s3_csv/config.py
+++ b/tap_s3_csv/config.py
@@ -13,6 +13,8 @@ CONFIG_CONTRACT = Schema({
         Required('pattern'): str,
         Required('key_properties'): [str],
         Required('format'): Any('csv', 'excel'),
+        Optional('unzip'): bool,
+        Optional('delimiter'): str,
         Optional('search_prefix'): str,
         Optional('field_names'): [str],
         Optional('worksheet_name'): str,

--- a/tap_s3_csv/config.py
+++ b/tap_s3_csv/config.py
@@ -15,6 +15,7 @@ CONFIG_CONTRACT = Schema({
         Required('format'): Any('csv', 'excel'),
         Optional('unzip'): bool,
         Optional('delimiter'): str,
+        Optional('quoting'): Any('QUOTE_MINIMAL', 'QUOTE_ALL', 'QUOTE_NONNUMERIC', 'QUOTE_NONE'),
         Optional('search_prefix'): str,
         Optional('field_names'): [str],
         Optional('worksheet_name'): str,

--- a/tap_s3_csv/csv_handler.py
+++ b/tap_s3_csv/csv_handler.py
@@ -2,6 +2,9 @@ import codecs
 import csv
 import re
 
+import zlib
+import io
+
 
 def generator_wrapper(reader):
     to_return = {}
@@ -24,18 +27,45 @@ def generator_wrapper(reader):
         yield to_return
 
 
+def gunzip(stream):
+    dec = zlib.decompressobj(32 + zlib.MAX_WBITS)
+    for chunk in stream:
+        rv = dec.decompress(chunk)
+        if rv:
+            yield rv
+
+
+def iter_lines(stream):
+    buf = ""
+    for chunk in stream:
+        for byte in chunk:
+            char = chr(byte)
+            if char == '\n':
+                yield buf.encode('utf-8')
+                buf = ""
+            else:
+                buf += char
+
+
 def get_row_iterator(table_spec, file_handle):
+
+    if table_spec.get('unzip'):
+        raw_stream = iter_lines(gunzip(file_handle._raw_stream))
+    else:
+        raw_stream = file_handle._raw_stream
+
     # we use a protected member of the s3 object, _raw_stream, here to create
     # a generator for data from the s3 file.
     # pylint: disable=protected-access
     file_stream = codecs.iterdecode(
-        file_handle._raw_stream, encoding='utf-8')
+        raw_stream, encoding='utf-8')
 
     field_names = None
 
     if 'field_names' in table_spec:
         field_names = table_spec['field_names']
 
-    reader = csv.DictReader(file_stream, fieldnames=field_names)
+    delimiter = table_spec.get('delimiter', ',')
+    reader = csv.DictReader(file_stream, delimiter=delimiter, fieldnames=field_names)
 
     return generator_wrapper(reader)


### PR DESCRIPTION
- Adds a `delimiter` (string) field to control the csv delimiter
- Adds an `unzip` (bool) field to optionally gunzip the file before reading it as a csv

(work in progress)