### PR TITLE
allow no counts after deduping

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.json
 *.egg-info/
 *.pyc
+.idea/

--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,7 @@ setup(name='tap-s3-csv',
       py_modules=['tap_s3_csv'],
       install_requires=[
           'boto3==1.4.4',
+          'smart_open==1.7.1',
           'singer-python==1.5.0',
           'voluptuous==0.10.5',
           'xlrd==1.0.0',

--- a/tap_s3_csv/__init__.py
+++ b/tap_s3_csv/__init__.py
@@ -148,6 +148,9 @@ def do_sync(args):
     for table in config['tables']:
         state = sync_table(config, state, table)
 
+    state = {'COMPLETED': True}
+    singer.write_state(state)
+
     logger.info('Done syncing.')
 
 

--- a/tap_s3_csv/__init__.py
+++ b/tap_s3_csv/__init__.py
@@ -3,6 +3,7 @@ import json
 import singer
 
 import dateutil
+
 import tap_s3_csv.s3 as s3
 import tap_s3_csv.conversion as conversion
 import tap_s3_csv.config

--- a/tap_s3_csv/config.py
+++ b/tap_s3_csv/config.py
@@ -4,8 +4,6 @@ from tap_s3_csv.logger import LOGGER as logger
 from voluptuous import Schema, Required, Any, Optional
 
 CONFIG_CONTRACT = Schema({
-    Required('aws_access_key_id'): str,
-    Required('aws_secret_access_key'): str,
     Required('start_date'): str,
     Required('bucket'): str,
     Required('tables'): [{

--- a/tap_s3_csv/conversion.py
+++ b/tap_s3_csv/conversion.py
@@ -73,7 +73,7 @@ def count_sample(sample, start=None):
 
 
 def count_samples(samples):
-    to_return = None
+    to_return = {}
 
     for sample in samples:
         to_return = count_sample(sample, to_return)

--- a/tap_s3_csv/conversion.py
+++ b/tap_s3_csv/conversion.py
@@ -111,6 +111,9 @@ def generate_schema(samples):
     to_return = {}
     counts = count_samples(samples)
 
+    if not counts:
+        return to_return
+
     for key, value in counts.items():
         datatype = pick_datatype(value)
 

--- a/tap_s3_csv/csv_handler.py
+++ b/tap_s3_csv/csv_handler.py
@@ -1,4 +1,3 @@
-import codecs
 import csv
 import re
 
@@ -25,17 +24,11 @@ def generator_wrapper(reader):
 
 
 def get_row_iterator(table_spec, file_handle):
-    # we use a protected member of the s3 object, _raw_stream, here to create
-    # a generator for data from the s3 file.
-    # pylint: disable=protected-access
-    file_stream = codecs.iterdecode(
-        file_handle._raw_stream, encoding='utf-8')
-
     field_names = None
 
     if 'field_names' in table_spec:
         field_names = table_spec['field_names']
 
-    reader = csv.DictReader(file_stream, fieldnames=field_names)
+    reader = csv.DictReader(file_handle, fieldnames=field_names)
 
     return generator_wrapper(reader)

--- a/tap_s3_csv/format_handler.py
+++ b/tap_s3_csv/format_handler.py
@@ -5,10 +5,7 @@ import tap_s3_csv.excel_handler
 
 def get_file_handle(config, s3_path):
     bucket = config['bucket']
-    s3_client = boto3.resource(
-        's3',
-        aws_access_key_id=config['aws_access_key_id'],
-        aws_secret_access_key=config['aws_secret_access_key'])
+    s3_client = boto3.resource('s3')
 
     s3_bucket = s3_client.Bucket(bucket)
     s3_object = s3_bucket.Object(s3_path)

--- a/tap_s3_csv/format_handler.py
+++ b/tap_s3_csv/format_handler.py
@@ -1,15 +1,13 @@
-import boto3
+from smart_open import smart_open
+
 import tap_s3_csv.csv_handler
 import tap_s3_csv.excel_handler
 
 
 def get_file_handle(config, s3_path):
     bucket = config['bucket']
-    s3_client = boto3.resource('s3')
-
-    s3_bucket = s3_client.Bucket(bucket)
-    s3_object = s3_bucket.Object(s3_path)
-    return s3_object.get()['Body']
+    s3_uri = f"s3://{bucket}/{s3_path}"
+    return smart_open(s3_uri, 'r')
 
 
 def get_row_iterator(config, table_spec, s3_path):

--- a/tap_s3_csv/s3.py
+++ b/tap_s3_csv/s3.py
@@ -82,10 +82,7 @@ def get_input_files_for_table(config, table_spec, modified_since=None):
 
 
 def list_files_in_bucket(config, bucket, search_prefix=None):
-    s3_client = boto3.client(
-        's3',
-        aws_access_key_id=config['aws_access_key_id'],
-        aws_secret_access_key=config['aws_secret_access_key'])
+    s3_client = boto3.client('s3')
 
     s3_objects = []
 


### PR DESCRIPTION
Based on airbrake and log messages, I've identified that the issue that cause `generate_schema` to fail was the case where no new data was being generated. This should only happen when the dedup clause in Athena returns no data. Therefore, I added a check to handle said case. 